### PR TITLE
Improve accessibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:20-alpine3.18 AS build
+FROM docker.io/node:20-alpine3.18 AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
 RUN npm run build
 
-FROM nginx:alpine AS runtime
+FROM docker.io/nginx:alpine AS runtime
 COPY ./docker/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 

--- a/src/components/about/about.module.css
+++ b/src/components/about/about.module.css
@@ -86,5 +86,9 @@
     &:hover {
       background-color: var(--color-neutral-100);
     }
+
+    &:focus-visible {
+      outline: 1px solid white;
+    }
   }
 }

--- a/src/components/buttons/play/play.module.css
+++ b/src/components/buttons/play/play.module.css
@@ -27,4 +27,8 @@
   & span {
     font-size: var(--font-lg);
   }
+
+  &:focus-visible {
+    outline: 1px solid white;
+  }
 }

--- a/src/components/buttons/unselect/unselect.module.css
+++ b/src/components/buttons/unselect/unselect.module.css
@@ -23,6 +23,10 @@
   &:hover {
     background-color: var(--color-neutral-200);
   }
+
+  &:focus-visible {
+    outline: 1px solid white;
+  }
 }
 
 .tooltip {

--- a/src/components/sound/favorite/favorite.module.css
+++ b/src/components/sound/favorite/favorite.module.css
@@ -24,4 +24,8 @@
   &.isFavorite {
     color: var(--color-foreground);
   }
+
+  &:focus-visible {
+    outline: 1px solid white;
+  }
 }

--- a/src/components/sound/sound.tsx
+++ b/src/components/sound/sound.tsx
@@ -65,20 +65,34 @@ export function Sound({
   }, [unselect, setVolume, id]);
 
   const toggle = useCallback(() => {
-    if (isSelected) return _unselect();
+    if (isSelected) _unselect();
+    else _select();
+  }, [isSelected, _select, _unselect]);
 
-    _select();
-  }, [isSelected, _unselect, _select]);
+  const handleClick = useCallback(() => {
+    toggle();
+  }, [toggle]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Enter') {
+        toggle();
+      }
+    },
+    [toggle],
+  );
 
   return (
     <div
+      role="button"
+      tabIndex={0}
       className={cn(
         styles.sound,
         isSelected && styles.selected,
         hidden && styles.hidden,
       )}
-      onClick={toggle}
-      onKeyDown={toggle}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
     >
       <Favorite id={id} />
       <div className={styles.icon}>


### PR DESCRIPTION
I tried to improve accessibility since Moodist was not very usable with keyboard.

Also added a small commit to make it easier for those who, like me, use podman instead of Docker. I can put that it a different merge request if you prefer.

Edit: what was wrong with keyboard was the lack of visibility on some focused objects. And pressing "tab" to switch to a new sound would start it until we would switch to the next one. Also, pressing tab + shift to go backwards would just start the sounds and not stop it when switching to the previous one. This is due to a key tab or shift being pressed. So I thought I'd specifiy "Enter" to start or stop a sound from being played.