### PR TITLE
fix: cancel buttons on pomodoro settings will now cancel properly

### DIFF
--- a/src/components/toolbox/pomodoro/setting/setting.tsx
+++ b/src/components/toolbox/pomodoro/setting/setting.tsx
@@ -14,10 +14,16 @@ interface SettingProps {
 export function Setting({ onChange, onClose, show, times }: SettingProps) {
   const [values, setValues] = useState(times);
 
+  const initialTimes = times;
+
   useEffect(() => setValues(times), [times]);
 
   const handleChange = (id: string) => (value: number) => {
     setValues(prev => ({ ...prev, [id]: value * 60 }));
+  };
+
+  const handleCancel = () => {
+    setValues(initialTimes);
   };
 
   const handleSubmit = e => {
@@ -51,14 +57,7 @@ export function Setting({ onChange, onClose, show, times }: SettingProps) {
         />
 
         <div className={styles.buttons}>
-          <button
-            onClick={e => {
-              e.preventDefault();
-              onClose();
-            }}
-          >
-            Cancel
-          </button>
+          <button onClick={handleCancel}>Cancel</button>
           <button className={styles.primary}>Save</button>
         </div>
       </form>


### PR DESCRIPTION
Canceling change in the settings (such as the duration of a pause) would not cancel it.