### PR TITLE
accessibility: ignore icons for screen readers

### DIFF
--- a/src/components/sound/sound.tsx
+++ b/src/components/sound/sound.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, forwardRef } from 'react';
 import { ImSpinner9 } from 'react-icons/im/index';
 
 import { Range } from './range';
@@ -21,16 +21,19 @@ interface SoundProps extends Sound {
   unselectHidden: (key: string) => void;
 }
 
-export function Sound({
-  functional,
-  hidden,
-  icon,
-  id,
-  label,
-  selectHidden,
-  src,
-  unselectHidden,
-}: SoundProps) {
+export const Sound = forwardRef(function Sound(
+  {
+    functional,
+    hidden,
+    icon,
+    id,
+    label,
+    selectHidden,
+    src,
+    unselectHidden,
+  }: SoundProps,
+  ref,
+) {
   const isPlaying = useSoundStore(state => state.isPlaying);
   const play = useSoundStore(state => state.play);
   const select = useSoundStore(state => state.select);
@@ -82,6 +85,7 @@ export function Sound({
   return (
     <div
       aria-label={`${label} sound`}
+      ref={ref}
       role="button"
       tabIndex={0}
       className={cn(
@@ -108,4 +112,4 @@ export function Sound({
       <Range id={id} label={label} />
     </div>
   );
-}
+});

--- a/src/components/sounds/sounds.tsx
+++ b/src/components/sounds/sounds.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useRef } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 
 import { Sound } from '@/components/sound';
@@ -18,6 +18,7 @@ interface SoundsProps {
 
 export function Sounds({ functional, id, sounds }: SoundsProps) {
   const [showAll, setShowAll] = useLocalStorage(`${id}-show-more`, false);
+  const soundToFocusRef = useRef<HTMLDivElement>(null);
 
   const [hiddenSelections, setHiddenSelections] = useState<{
     [key: string]: boolean;
@@ -43,6 +44,17 @@ export function Sounds({ functional, id, sounds }: SoundsProps) {
     }));
   }, []);
 
+  const handleOnClick = () => {
+    setShowAll(prev => !prev);
+    if (showAll && sounds.length > 6) {
+      setTimeout(() => {
+        if (soundToFocusRef.current) {
+          soundToFocusRef.current.focus();
+        }
+      }, 0);
+    }
+  };
+
   const variants = mix(fade(), scale(0.9));
 
   return (
@@ -51,6 +63,7 @@ export function Sounds({ functional, id, sounds }: SoundsProps) {
         {sounds.map((sound, index) => (
           <Sound
             key={sound.label}
+            ref={index === 6 ? soundToFocusRef : null}
             {...sound}
             functional={functional}
             hidden={!showAll && index > 5}
@@ -78,7 +91,7 @@ export function Sounds({ functional, id, sounds }: SoundsProps) {
               styles.button,
               hasHiddenSelection && !showAll && styles.active,
             )}
-            onClick={() => setShowAll(prev => !prev)}
+            onClick={handleOnClick}
           >
             {showAll ? 'Show Less' : 'Show More'}
           </motion.button>


### PR DESCRIPTION
Couldn't do them all because I'm not sure about how to handle some of them but I'm 99% sure for icons in that MR that we don't want them to be read out loud by screen readers, it would just pollute the voice synthesis transcription.

Small step after small step, the app should be more and more accessible, hopefully ! :)