### PR TITLE
accessibility: ignore icons for screen readers

### DIFF
--- a/src/components/buttons/play/play.tsx
+++ b/src/components/buttons/play/play.tsx
@@ -48,14 +48,14 @@ export function PlayButton() {
     >
       {isPlaying ? (
         <>
-          <span>
+          <span aria-hidden="true">
             <BiPause />
           </span>{' '}
           Pause
         </>
       ) : (
         <>
-          <span>
+          <span aria-hidden="true">
             <BiPlay />
           </span>{' '}
           Play

--- a/src/components/categories/donate/donate.tsx
+++ b/src/components/categories/donate/donate.tsx
@@ -9,7 +9,7 @@ export function Donate() {
     <div className={styles.donate}>
       <div className={styles.iconContainer}>
         <div className={styles.tail} />
-        <div className={styles.icon}>
+        <div aria-hidden="true" className={styles.icon}>
           <FaCoffee />
         </div>
       </div>

--- a/src/components/category/category.tsx
+++ b/src/components/category/category.tsx
@@ -19,7 +19,9 @@ export function Category({
     <div className={styles.category} id={`category-${id}`}>
       <div className={styles.iconContainer}>
         <div className={styles.tail} />
-        <div className={styles.icon}>{icon}</div>
+        <div aria-hidden="true" className={styles.icon}>
+          {icon}
+        </div>
       </div>
 
       <div className={styles.title}>{title}</div>

--- a/src/components/hero.astro
+++ b/src/components/hero.astro
@@ -13,6 +13,7 @@ const count = soundCount();
     <div class="wrapper">
       <img
         alt="Faded Moodist Logo"
+        aria-hidden="true"
         class="logo"
         height={45}
         src="/logo.svg"
@@ -28,7 +29,7 @@ const count = soundCount();
       <h1 class="desc">Ambient sounds for focus and calm.</h1>
 
       <p class="sounds">
-        <span class="icon">
+        <span aria-hidden="true" class="icon">
           <BsSoundwave />
         </span>
         <span>{count} Sounds</span>

--- a/src/components/sound/favorite/favorite.tsx
+++ b/src/components/sound/favorite/favorite.tsx
@@ -56,6 +56,7 @@ export function Favorite({ id, label }: FavoriteProps) {
       >
         <motion.span
           animate="show"
+          aria-hidden="true"
           exit="hidden"
           initial="hidden"
           key={isFavorite ? `${id}-is-favorite` : `${id}-not-favorite`}

--- a/src/components/sound/sound.tsx
+++ b/src/components/sound/sound.tsx
@@ -97,11 +97,11 @@ export const Sound = forwardRef<HTMLDivElement, SoundProps>(function Sound(
       <Favorite id={id} label={label} />
       <div className={styles.icon}>
         {isLoading ? (
-          <span className={styles.spinner}>
+          <span aria-hidden="true" className={styles.spinner}>
             <ImSpinner9 />
           </span>
         ) : (
-          icon
+          <span aria-hidden="true">{icon}</span>
         )}
       </div>
       <div className={styles.label} id={id}>


### PR DESCRIPTION
Couldn't do them all because I'm not sure about how to handle some of them but I'm 99% sure for icons in that MR that we don't want them to be read out loud by screen readers, it would just pollute the voice synthesis transcription.

Small step after small step, the app should be more and more accessible, hopefully ! :)

Edit: also added a commit to use a proper label in sliders instead of aria-label. ARIA properties must be used sparingly. It is not a big deal functionally but it cleans the accessibility inspector reports. :)