### PR TITLE
feat: fix modal and scrollbar layout shift

### DIFF
--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -19,6 +19,8 @@ interface ModalProps {
   wide?: boolean;
 }
 
+const TRANSITION_DURATION = 300;
+
 export function Modal({
   children,
   lockBody = true,
@@ -34,9 +36,12 @@ export function Modal({
 
   useEffect(() => {
     if (show && lockBody) {
-      document.body.style.overflow = 'hidden';
+      document.body.style.overflowY = 'hidden';
     } else if (lockBody) {
-      document.body.style.overflow = 'auto';
+      // Wait for transition to finish before allowing scrollbar to return
+      setTimeout(() => {
+        document.body.style.overflowY = 'auto';
+      }, TRANSITION_DURATION);
     }
   }, [show, lockBody]);
 
@@ -68,6 +73,7 @@ export function Modal({
         <motion.div
           {...animationProps}
           className={styles.overlay}
+          transition={{ duration: TRANSITION_DURATION / 1000 }}
           variants={variants.overlay}
           onClick={onClose}
           onKeyDown={onClose}
@@ -76,6 +82,7 @@ export function Modal({
           <motion.div
             {...animationProps}
             className={cn(styles.content, wide && styles.wide)}
+            transition={{ duration: TRANSITION_DURATION / 1000 }}
             variants={variants.modal}
           >
             <button className={styles.close} onClick={onClose}>

--- a/src/components/toolbar/toolbar.module.css
+++ b/src/components/toolbar/toolbar.module.css
@@ -3,7 +3,7 @@
   bottom: 20px;
   left: 0;
   z-index: 15;
-  width: 100%;
+  width: 100vw;
 
   .container {
     display: flex;

--- a/src/styles/base/base.css
+++ b/src/styles/base/base.css
@@ -16,6 +16,9 @@ body {
   font-size: var(--font-base);
   color: var(--color-foreground);
   background-color: var(--color-neutral-50);
+  /* Workaround for modal and scrollbar layout shifts */
+  width: 100vw;
+  overflow-x: hidden;
 }
 
 ::selection {


### PR DESCRIPTION
Hi @remvze,

First of all, thanks for making such a cool product!

I was messing around with it today on desktop and noticed there's a fair bit of layout shifting being caused by modals and menus and the way they hide the scrollbar.

This appears to be a known issue with some of Radix/Shadcn's components as discussed here: https://github.com/shadcn-ui/ui/issues/977

Let me know what you think and if I've missed anything, happy to make adjustments.

Cheers.