### PR TITLE
feat(audio): improve resource cleanup for Safari compatibility

### DIFF
--- a/src/components/modals/binaural/binaural.tsx
+++ b/src/components/modals/binaural/binaural.tsx
@@ -100,9 +100,22 @@ export function BinauralModal({ onClose, show }: BinauralProps) {
   const stopSound = useCallback(() => {
     if (!isPlaying) return;
 
+    // Stop oscillators
     leftOscillatorRef.current?.stop();
     rightOscillatorRef.current?.stop();
-    audioContextRef.current?.close();
+
+    // Unload oscillators
+    leftOscillatorRef.current = null;
+    rightOscillatorRef.current = null;
+
+    // Close and unload AudioContext
+    if (audioContextRef.current) {
+      audioContextRef.current.close();
+      audioContextRef.current = null;
+    }
+
+    // Unload gain node
+    gainNodeRef.current = null;
 
     setIsPlaying(false);
   }, [isPlaying]);
@@ -127,11 +140,9 @@ export function BinauralModal({ onClose, show }: BinauralProps) {
   useEffect(() => {
     // Cleanup when component unmounts
     return () => {
-      if (isPlaying) {
-        stopSound();
-      }
+      stopSound();
     };
-  }, [isPlaying, stopSound]);
+  }, [stopSound]);
 
   useEffect(() => {
     // Update frequencies when a preset is selected


### PR DESCRIPTION
### Summary:
This PR improves audio resource cleanup for Safari and other browsers by properly stopping and unloading Web Audio API resources when pausing or stopping playback. This prevents audio from becoming locked or exhausted after repeated play/pause cycles.

### Details:

- Ensures oscillators and gain nodes are set to null after stopping.
- Closes and unloads the AudioContext to release resources.
- Fixes issues with audio playback reliability, especially in Safari.

### Testing:
Tested in Safari and Chrome. Audio playback now works reliably after multiple play/pause actions.