### PR TITLE
fix: prevent multiple simultaneous sound plays

### DIFF
--- a/src/hooks/use-sound.ts
+++ b/src/hooks/use-sound.ts
@@ -30,6 +30,7 @@ export function useSound(
   html5: boolean = false,
 ) {
   const [hasLoaded, setHasLoaded] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
   const isLoading = useLoadingStore(state => state.loaders[src]);
   const setIsLoading = useLoadingStore(state => state.set);
 
@@ -40,6 +41,11 @@ export function useSound(
     if (isBrowser) {
       sound = new Howl({
         html5,
+        onend: () => {
+          if (!options.loop) {
+            setIsPlaying(false);
+          }
+        },
         onload: () => {
           setIsLoading(src, false);
           setHasLoaded(true);
@@ -50,7 +56,7 @@ export function useSound(
     }
 
     return sound;
-  }, [src, isBrowser, setIsLoading, html5, options.preload]);
+  }, [src, isBrowser, setIsLoading, html5, options.preload, options.loop]);
 
   useEffect(() => {
     if (sound) {
@@ -70,22 +76,25 @@ export function useSound(
           sound.load();
         }
 
-        if (!sound.playing()) {
+        if (!isPlaying) {
+          setIsPlaying(true);
           sound.play();
         }
 
         if (typeof cb === 'function') sound.once('end', cb);
       }
     },
-    [src, setIsLoading, sound, hasLoaded, isLoading],
+    [src, setIsLoading, sound, hasLoaded, isLoading, isPlaying],
   );
 
   const stop = useCallback(() => {
-    if (sound) sound.stop();
+    setIsPlaying(false);
+    sound?.stop();
   }, [sound]);
 
   const pause = useCallback(() => {
-    if (sound) sound.pause();
+    setIsPlaying(false);
+    sound?.pause();
   }, [sound]);
 
   const fadeOut = useCallback(


### PR DESCRIPTION
I was experimenting with some features and ran into an issue.
Currently, every sound is played multiple times simultaneously.

I added this log in the `use-sound` custom hook:
```
if (!sound.playing()) {
  const id = sound.play();
  console.log(`Playing ${id}`);
}
```
And with a single sound selected, this was the output:
<img width="615" height="104" alt="image" src="https://github.com/user-attachments/assets/059527c1-7b9f-4bfc-b42b-e809f8c673e4" />

After some digging, I found that sound.playing() is not reliable when sound.play() is called multiple times within a short timeframe.
This is because there’s a small delay before the sound state changes, due to [asynchronous operations](https://github.com/goldfire/howler.js/blob/a2a47933f1ffcee659e4939a65e075fa7f25706c/src/howler.core.js#L798C9-L807C24) (queued actions).

The solution I found is to track this state manually on our side, to prevent additional sound.play() calls.

This bug is not noticeable to the user, but it makes things more complicated when trying to implement new sound-level features.