### PR TITLE
fix(ui): body should not be scrollable when opening pomodoro settings

### DIFF
--- a/src/components/toolbar/menu/menu.tsx
+++ b/src/components/toolbar/menu/menu.tsx
@@ -179,11 +179,7 @@ export function Menu() {
         show={modals.shortcuts}
         onClose={() => close('shortcuts')}
       />
-      <Pomodoro
-        open={() => open('pomodoro')}
-        show={modals.pomodoro}
-        onClose={() => close('pomodoro')}
-      />
+      <Pomodoro show={modals.pomodoro} onClose={() => close('pomodoro')} />
       <Notepad show={modals.notepad} onClose={() => close('notepad')} />
       <Todo show={modals.todo} onClose={() => close('todo')} />
       <Countdown show={modals.countdown} onClose={() => close('countdown')} />

--- a/src/components/toolbox/pomodoro/pomodoro.tsx
+++ b/src/components/toolbox/pomodoro/pomodoro.tsx
@@ -17,11 +17,10 @@ import styles from './pomodoro.module.css';
 
 interface PomodoroProps {
   onClose: () => void;
-  open: () => void;
   show: boolean;
 }
 
-export function Pomodoro({ onClose, open, show }: PomodoroProps) {
+export function Pomodoro({ onClose, show }: PomodoroProps) {
   const [showSetting, setShowSetting] = useState(false);
 
   const [selectedTab, setSelectedTab] = useState('pomodoro');
@@ -130,7 +129,6 @@ export function Pomodoro({ onClose, open, show }: PomodoroProps) {
               icon={<IoMdSettings />}
               tooltip="Change Times"
               onClick={() => {
-                onClose();
                 setShowSetting(true);
               }}
             />
@@ -167,11 +165,9 @@ export function Pomodoro({ onClose, open, show }: PomodoroProps) {
         onChange={times => {
           setShowSetting(false);
           setTimes(times);
-          open();
         }}
         onClose={() => {
           setShowSetting(false);
-          open();
         }}
       />
     </>


### PR DESCRIPTION
Hi! First and foremost, thanks for keeping moodist free!

I noticed that opening the **Pomodoro Settings Modal** made the body scrollable: this is probably caused by the `else if`  condition in the first `useEffect` of the **Pomodoro main Modal**.

The Modal rendered by the Settings component has `lockBody={false}` so it seems like there is already an intention to prevent this "secondary" modal to influence the body scroll functionality, but as of right now it also closes the main modal which has `lockBody={true}`.

I think that a simple fix is keeping the main modal open: we lose its animations when opening/closing the settings but it should be fine for the UX since we are still in the "Pomodoro application context".

Let me know if there are any problems regarding this PR!