### PR TITLE
feat(docker): Add IPv6 dual-stack support to nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,9 @@ services:
     restart: always
     ports:
       - '8080:8080'
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8080/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -7,6 +7,7 @@ events {
 http {
   server {
     listen 8080;
+    listen [::]:8080;
     server_name   _;
 
     root   /usr/share/nginx/html;


### PR DESCRIPTION
## Description
Adds IPv6 support to nginx configuration and includes healthcheck for Docker deployments.

## Problem
Since Docker Engine v26, containers keep IPv6 enabled on the loopback interface by default. The current nginx configuration only listens on IPv4, which can cause connectivity issues when applications or healthchecks resolve `localhost` to `::1` (IPv6).

## Solution
- Added `listen [::]:8080;` directive to nginx.conf for dual-stack support (separate IPv4 and IPv6 sockets)
- Added healthcheck to docker-compose.yml using explicit IPv4 address for maximum compatibility

## Testing
- ✅ Verified nginx listens on both IPv4 (`0.0.0.0:8080`) and IPv6 (`:::8080`)
- ✅ Confirmed healthcheck passes with `wget -q --spider http://127.0.0.1:8080/`
- ✅ Tested connectivity via `localhost`, `127.0.0.1`, and `[::1]`

## Benefits
- Improved compatibility with modern Docker environments
- Enables proper container health monitoring

## Note
Uses separate IPv4/IPv6 sockets for standard dual-stack configuration. On systems with IPv6 completely disabled at the kernel level (rare), users can remove the `listen [::]:8080;` line from nginx.conf.

## Related
- Addresses similar issue discussed in [home-assistant/addons](https://github.com/home-assistant/addons/pull/3475)
