### PR TITLE
feat: add toggle for favorites auto-jump behavior

### DIFF
--- a/src/components/sounds/sound/favorite/favorite.tsx
+++ b/src/components/sounds/sound/favorite/favorite.tsx
@@ -17,13 +17,16 @@ interface FavoriteProps {
 
 export function Favorite({ id, label }: FavoriteProps) {
   const isFavorite = useSoundStore(state => state.sounds[id].isFavorite);
+  const autoScrollToFavorites = useSoundStore(
+    state => state.autoScrollToFavorites,
+  );
   const toggleFavorite = useSoundStore(state => state.toggleFavorite);
 
   const handleToggle = async () => {
     toggleFavorite(id);
 
     // Check if false -> true
-    if (!isFavorite) {
+    if (!isFavorite && autoScrollToFavorites) {
       await waitUntil(
         () => !!document.getElementById('category-favorites'),
         50,

--- a/src/components/toolbar/menu/items/favorite-scroll.tsx
+++ b/src/components/toolbar/menu/items/favorite-scroll.tsx
@@ -1,0 +1,22 @@
+import { BiSolidHeart } from 'react-icons/bi/index';
+
+import { Item } from '../item';
+import { useSoundStore } from '@/stores/sound';
+
+export function FavoriteScroll() {
+  const autoScrollToFavorites = useSoundStore(
+    state => state.autoScrollToFavorites,
+  );
+  const setAutoScrollToFavorites = useSoundStore(
+    state => state.setAutoScrollToFavorites,
+  );
+
+  return (
+    <Item
+      active={autoScrollToFavorites}
+      icon={<BiSolidHeart />}
+      label="Auto-jump to Favorites"
+      onClick={() => setAutoScrollToFavorites(!autoScrollToFavorites)}
+    />
+  );
+}

--- a/src/components/toolbar/menu/items/index.ts
+++ b/src/components/toolbar/menu/items/index.ts
@@ -1,4 +1,5 @@
 export { Shuffle as ShuffleItem } from './shuffle';
+export { FavoriteScroll as FavoriteScrollItem } from './favorite-scroll';
 export { Share as ShareItem } from './share';
 export { Donate as DonateItem } from './donate';
 export { Source as SourceItem } from './source';

--- a/src/components/toolbar/menu/menu.tsx
+++ b/src/components/toolbar/menu/menu.tsx
@@ -6,6 +6,7 @@ import { AnimatePresence, motion } from 'motion/react';
 
 import {
   ShuffleItem,
+  FavoriteScrollItem,
   ShareItem,
   DonateItem,
   SourceItem,
@@ -128,6 +129,7 @@ export function Menu() {
                     <PresetsItem open={() => open('presets')} />
                     <ShareItem open={() => open('shareLink')} />
                     <ShuffleItem />
+                    <FavoriteScrollItem />
                     <SleepTimerItem open={() => open('sleepTimer')} />
 
                     <Divider />

--- a/src/stores/sound/index.ts
+++ b/src/stores/sound/index.ts
@@ -20,6 +20,7 @@ export const useSoundStore = create<SoundState & SoundActions>()(
         ),
       name: 'moodist-sounds',
       partialize: state => ({
+        autoScrollToFavorites: state.autoScrollToFavorites,
         globalVolume: state.globalVolume,
         sounds: state.sounds,
       }),

--- a/src/stores/sound/sound.actions.ts
+++ b/src/stores/sound/sound.actions.ts
@@ -11,6 +11,7 @@ export interface SoundActions {
   play: () => void;
   restoreHistory: () => void;
   select: (id: string) => void;
+  setAutoScrollToFavorites: (autoScrollToFavorites: boolean) => void;
   setGlobalVolume: (volume: number) => void;
   setVolume: (id: string, volume: number) => void;
   shuffle: () => void;
@@ -71,6 +72,10 @@ export const createActions: StateCreator<
           [id]: { ...get().sounds[id], isSelected: true },
         },
       });
+    },
+
+    setAutoScrollToFavorites(autoScrollToFavorites) {
+      set({ autoScrollToFavorites });
     },
 
     setGlobalVolume(volume) {

--- a/src/stores/sound/sound.state.ts
+++ b/src/stores/sound/sound.state.ts
@@ -5,6 +5,7 @@ import type { SoundActions } from './sound.actions';
 import { sounds } from '@/data/sounds';
 
 export interface SoundState {
+  autoScrollToFavorites: boolean;
   getFavorites: () => Array<string>;
   globalVolume: number;
   history: {
@@ -33,6 +34,7 @@ export const createState: StateCreator<
   SoundState
 > = (set, get) => {
   const state: SoundState = {
+    autoScrollToFavorites: true,
     getFavorites() {
       const { sounds } = get();
       const ids = Object.keys(sounds);


### PR DESCRIPTION
### Motivation
- Prevent adding a favorite from forcing a scroll/jump to the Favorites category (which interrupts filtering/selection flows) while keeping the current behavior as the default.
- Allow users to opt out of the auto-jump without removing the feature for users who prefer it.

### Description
- Add a persisted `autoScrollToFavorites` boolean to the sound store (default `true`) and expose a `setAutoScrollToFavorites` action in `src/stores/sound/*`.
- Persist the new preference via the store `partialize` config so it survives reloads (`src/stores/sound/index.ts`).
- Update the favorite button logic to only call `scrollIntoView` when `autoScrollToFavorites` is `true` (`src/components/sounds/sound/favorite/favorite.tsx`).
- Add a new menu toggle item `Auto-jump to Favorites` implemented in `src/components/toolbar/menu/items/favorite-scroll.tsx` and wire it into the menu (`src/components/toolbar/menu/items/index.ts` and `src/components/toolbar/menu/menu.tsx`).

### Testing
- Ran the linter with `npm run lint` and it completed successfully.
- No unit tests were added or run as part of this change.