### PR TITLE
fix(docker): set OCI image labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,14 @@ RUN pnpm run build
 
 FROM docker.io/caddy:latest
 
+LABEL org.opencontainers.image.title="Moodist" \
+      org.opencontainers.image.description="Ambient sounds for focus and calm" \
+      org.opencontainers.image.source="https://github.com/remvze/moodist" \
+      org.opencontainers.image.url="https://moodist.mvze.net/" \
+      org.opencontainers.image.documentation="https://github.com/remvze/moodist" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="remvze"
+
 COPY ./Caddyfile /etc/caddy/Caddyfile
 COPY --from=build /app/dist /var/www/html
 


### PR DESCRIPTION
The published image inherits `org.opencontainers.image.*` labels from the `caddy` base image in the final stage, so tools that read those labels attribute the image to the Caddy project. For example, Renovate PRs updating `ghcr.io/remvze/moodist` link to caddyserver.com and the Caddy source repo instead of Moodist, and `podman inspect` reports the image as "Caddy" by "Light Code Labs" under the Apache-2.0 license.

Inherited labels can't be removed, only replaced, so this sets the static ones to Moodist's own values. Verified by building locally and inspecting the resulting labels (output below).

One known leftover: `org.opencontainers.image.version` still reports the Caddy version. Fixing that would need a build arg wired in from the release workflow, so I've left it out to keep this change minimal.

**Before** (`ghcr.io/remvze/moodist:v2.6.1` as published):

```json
{
  "org.opencontainers.image.description": "a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go",
  "org.opencontainers.image.documentation": "https://caddyserver.com/docs",
  "org.opencontainers.image.licenses": "Apache-2.0",
  "org.opencontainers.image.source": "https://github.com/caddyserver/caddy-docker",
  "org.opencontainers.image.title": "Caddy",
  "org.opencontainers.image.url": "https://caddyserver.com",
  "org.opencontainers.image.vendor": "Light Code Labs",
  "org.opencontainers.image.version": "v2.11.4"
}
```

**After** (built from this branch):

```json
{
  "io.buildah.version": "1.43.2",
  "org.opencontainers.image.description": "Ambient sounds for focus and calm",
  "org.opencontainers.image.documentation": "https://github.com/remvze/moodist",
  "org.opencontainers.image.licenses": "MIT",
  "org.opencontainers.image.source": "https://github.com/remvze/moodist",
  "org.opencontainers.image.title": "Moodist",
  "org.opencontainers.image.url": "https://moodist.mvze.net/",
  "org.opencontainers.image.vendor": "remvze",
  "org.opencontainers.image.version": "v2.11.4"
}
```

(`io.buildah.version` is from my local podman build, not the Dockerfile.)